### PR TITLE
Remove duplicate header on 404

### DIFF
--- a/web/app/themes/taxcentreofexcellence/404.php
+++ b/web/app/themes/taxcentreofexcellence/404.php
@@ -1,5 +1,3 @@
-<?php get_template_part('header'); ?>
-
 <div class="alert alert-warning">
   <?php _e('Sorry, but the page you were trying to view does not exist.', 'sage'); ?>
 </div>


### PR DESCRIPTION
Recent refactor of header and footer template left in a duplicate call
to the header file on the 404 page when it wasn't needed.