### PR TITLE
Fix caching issue whereby changes to CSS are not showing in the browser

### DIFF
--- a/web/app/themes/taxcentreofexcellence/lib/setup.php
+++ b/web/app/themes/taxcentreofexcellence/lib/setup.php
@@ -2,7 +2,17 @@
 
 namespace Roots\Sage\Setup;
 
-use Roots\Sage\Assets;
+function mix_asset($filename) {
+  $filename = '/' . $filename;
+  $manifest_path = dirname(__FILE__) . '/../dist/mix-manifest.json';
+  $manifest = json_decode(file_get_contents($manifest_path), true);
+
+  if (!isset($manifest[$filename])) {
+    error_log("Mix asset '$filename' does not exist in manifest.");
+  }
+
+  return get_stylesheet_directory_uri() . '/dist' . $manifest[$filename];
+}
 
 /**
  * Theme setup
@@ -26,19 +36,9 @@ function setup() {
 
   // Use main stylesheet for visual editor
   // To add custom styles edit /assets/styles/layouts/_tinymce.scss
-  add_editor_style(Assets\asset_path('styles/editor.css'));
+  add_editor_style(mix_asset('styles/editor.css'));
 }
 add_action('after_setup_theme', __NAMESPACE__ . '\\setup');
-
-function mix_asset($filename) {
-  $filename = '/' . $filename;
-  $manifest_path = dirname(__FILE__) . '/../dist/mix-manifest.json';
-  $manifest = json_decode(file_get_contents($manifest_path), true);
-  if (!isset($manifest[$filename])) {
-    error_log("Mix asset '$filename' does not exist in manifest.");
-  }
-  return get_stylesheet_directory_uri() . '/dist' . $manifest[$filename];
-}
 
 /**
  * Theme assets
@@ -46,17 +46,17 @@ function mix_asset($filename) {
 function assets() {
   wp_enqueue_style('sage/css', mix_asset('styles/main.css'), false, null);
 
-  wp_enqueue_style('sage/ie8', Assets\asset_path('styles/ie8.css'), false, null);
+  wp_enqueue_style('sage/ie8', mix_asset('styles/ie8.css'), false, null);
   wp_style_add_data('sage/ie8', 'conditional', 'IE 8');
 
-  wp_enqueue_style('sage/ie7', Assets\asset_path('styles/ie7.css'), false, null);
+  wp_enqueue_style('sage/ie7', mix_asset('styles/ie7.css'), false, null);
   wp_style_add_data('sage/ie7', 'conditional', 'IE 7');
 
   if (is_single() && comments_open() && get_option('thread_comments')) {
     wp_enqueue_script('comment-reply');
   }
 
-  wp_enqueue_script('sage/js', Assets\asset_path('scripts/main.js'), array('jquery'), null, true);
+  wp_enqueue_script('sage/js', mix_asset('scripts/main.js'), array('jquery'), null, true);
 
   wp_enqueue_script('sage/html5', 'https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js', array(), null);
   wp_script_add_data('sage/html5', 'conditional', 'lte IE 8');

--- a/web/app/themes/taxcentreofexcellence/lib/setup.php
+++ b/web/app/themes/taxcentreofexcellence/lib/setup.php
@@ -30,11 +30,21 @@ function setup() {
 }
 add_action('after_setup_theme', __NAMESPACE__ . '\\setup');
 
+function mix_asset($filename) {
+  $filename = '/' . $filename;
+  $manifest_path = dirname(__FILE__) . '/../dist/mix-manifest.json';
+  $manifest = json_decode(file_get_contents($manifest_path), true);
+  if (!isset($manifest[$filename])) {
+    error_log("Mix asset '$filename' does not exist in manifest.");
+  }
+  return get_stylesheet_directory_uri() . '/dist' . $manifest[$filename];
+}
+
 /**
  * Theme assets
  */
 function assets() {
-  wp_enqueue_style('sage/css', Assets\asset_path('styles/main.css'), false, null);
+  wp_enqueue_style('sage/css', mix_asset('styles/main.css'), false, null);
 
   wp_enqueue_style('sage/ie8', Assets\asset_path('styles/ie8.css'), false, null);
   wp_style_add_data('sage/ie8', 'conditional', 'IE 8');

--- a/web/app/themes/taxcentreofexcellence/webpack.mix.js
+++ b/web/app/themes/taxcentreofexcellence/webpack.mix.js
@@ -4,6 +4,8 @@ mix.setPublicPath('./dist/');
 
 mix.js('assets/scripts/main.js', 'scripts/main.js')
   .sass('assets/styles/main.scss', 'styles/main.css')
+  .sass('assets/styles/ie7.scss', 'styles/ie7.css')
+  .sass('assets/styles/ie8.scss', 'styles/ie8.css')
   .options({
     processCssUrls: false
   })


### PR DESCRIPTION
New changes to the stylesheet were not being reflected in all browsers.
A hard refresh of the browser fixed the issue. This suggested that
cache-busting was not enabled for this site. A quick inspection proved
this to be true.

As we are using webpack.mix.js we can take advantage of its
cache-busting functionality
(https://laravel.com/docs/6.x/mix#versioning-and-cache-busting).

Using a custom function `mix_asset` in
`web/app/themes/taxcentreofexcellence/lib/setup.php` we can take
advantage of the `mix-manifest.json` file that is automatically
generated when the `dist` assets are built.

The `mix-asset` function was adapted from the `mix-asset` function in
the wp-ppj project
(https://github.com/ministryofjustice/wp-ppj/blob/master/web/app/themes/ppj/functions.php).

Other sites should be checked to see if they have the same issue.